### PR TITLE
Fixed double zipping on windows workflows

### DIFF
--- a/.github/workflows/win-nuitka.yml
+++ b/.github/workflows/win-nuitka.yml
@@ -104,7 +104,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: pyTranscriber-win-${{ env.VERSION }}
-          path: ./dist/pyTranscriber-win-${{ env.VERSION }}.zip # Adjust this path if Nuitka outputs elsewhere
+          path: ./dist/pyTranscriber-win-${{ env.VERSION }} # Adjust this path if Nuitka outputs elsewhere
 
   download:
     runs-on: windows-latest

--- a/.github/workflows/win-nuitka.yml
+++ b/.github/workflows/win-nuitka.yml
@@ -96,15 +96,15 @@ jobs:
           Set-Location -Path dist
           Write-Host "Renaming main.exe to pyTranscriber-$env:VERSION.exe"
           Rename-Item -Force main.exe "pyTranscriber-$env:VERSION.exe"
-          Write-Host "Creating zip archive: pyTranscriber-$env:VERSION.zip"
-          Compress-Archive -Path "pyTranscriber-$env:VERSION.exe" -DestinationPath "pyTranscriber-win-$env:VERSION.zip"
+          # Write-Host "Creating zip archive: pyTranscriber-$env:VERSION.zip"
+          # Compress-Archive -Path "pyTranscriber-$env:VERSION.exe" -DestinationPath "pyTranscriber-win-$env:VERSION.zip"
         shell: pwsh 
      
       - name: Upload built executable
         uses: actions/upload-artifact@v4
         with:
           name: pyTranscriber-win-${{ env.VERSION }}
-          path: ./dist/pyTranscriber-win-${{ env.VERSION }} # Adjust this path if Nuitka outputs elsewhere
+          path: ./dist/pyTranscriber-${{ env.VERSION }}.exe # Adjust this path if Nuitka outputs elsewhere
 
   download:
     runs-on: windows-latest

--- a/.github/workflows/win-pyinstaller-dev2.yml
+++ b/.github/workflows/win-pyinstaller-dev2.yml
@@ -95,15 +95,15 @@ jobs:
           Set-Location -Path dist
           Write-Host "Renaming main.exe to pyTranscriber-$env:VERSION.exe"
           Rename-Item -Force main.exe "pyTranscriber-$env:VERSION.exe"
-          Write-Host "Creating zip archive: pyTranscriber-win-$env:VERSION.zip"
-          Compress-Archive -Path "pyTranscriber-$env:VERSION.exe" -DestinationPath "pyTranscriber-win-$env:VERSION.zip"
+          # Write-Host "Creating zip archive: pyTranscriber-win-$env:VERSION.zip"
+          # Compress-Archive -Path "pyTranscriber-$env:VERSION.exe" -DestinationPath "pyTranscriber-win-$env:VERSION.zip"
         shell: pwsh 
         
       - name: Upload built executable for Python ${{ matrix.python-version }}
         uses: actions/upload-artifact@v4
         with:
           name: pyTranscriber-win-${{ env.VERSION }}-py${{ matrix.python-version }}
-          path: ./dist/pyTranscriber-win-${{ env.VERSION }}.zip
+          path: ./dist/pyTranscriber-${{ env.VERSION }}.exe
 
   download:
     runs-on: windows-latest


### PR DESCRIPTION
As I mentioned here https://github.com/raryelcostasouza/pyTranscriber/issues/57#issuecomment-3229587221 , the actions/upload-artifact@v4 actually zips before doing anything and there were no need to zip the file manually. The pyInstaller version works fine but the nuitka version still has issue with opening the GUI. 
I have low experience on python but as I read through https://nuitka.net/info/pyqt5.html , it seems that nuitka is incompatible with pyqt5. 
I would love to learn Qt and python and help more and if I ever have the time, I will help.